### PR TITLE
Added docker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  plex-mqtt-connector:
+    build: .
+    ports:
+      - "5000:5000"

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.8-slim-buster
+ADD Mqtt-Plex-Connector.py .
+RUN pip install flask-restful paho-mqtt requests
+
+CMD [ "python", "./Mqtt-Plex-Connector.py" ]


### PR DESCRIPTION
dockerfile - definition to build a docker image
docker-compose.yml - tell docker-compose what to call the image and what port to forward

to run this with docker-compose:

1. clone repo
2. update mqtt host in Mqtt-Plex-Connector.py
3. run "docker-compose up -d"